### PR TITLE
Resolve clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,6 @@ criterion = { version = "0.2", optional = true } # for cargo bench
 [dev-dependencies]
 indoc = "0.2"
 
-[features]
-default = []
-benches = ["criterion"]
-
 [[bench]]
 name = "mod"
 harness = false

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "benches")]
 #[macro_use]
 extern crate criterion;
 extern crate glsl_include;


### PR DESCRIPTION
At this point, clippy is not something I want to integrate into the
project. I manually installed and ran:

rustup update nightly
cargo +nightly install --force clippy
cargo +nightly clippy

Additionally, remove the benches feature. At the time, I did not know I
could use an optional package name as a feature.

Closes #12